### PR TITLE
Add workflow_dispatch trigger to deploy_bookdown.yml

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -4,6 +4,7 @@ on:
      # Default branches below
        - main
        - master
+  workflow_dispatch:
 
 
 name: renderbook


### PR DESCRIPTION
Allows manual triggering of the bookdown render+deploy workflow from the GitHub Actions UI, so we can validate the pipeline without pushing a code change.