### PR TITLE
Run apt-get update before installing system deps

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -18,7 +18,9 @@ jobs:
       # More detail here, https://github.com/r-lib/actions
       # It's possible to define R and pandoc version if desired
       - name: Install other needed libs
-        run: sudo apt-get install -y libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install TinyTeX


### PR DESCRIPTION
The Ubuntu mirror periodically removes the old .deb after a minor security update is published. Without a fresh apt index, install fails with 404s for packages like libcurl4-openssl-dev and libpng-dev. This matches the pattern already used in jekyll-gh-pages.yml.