### PR TITLE
Unblock CI: apt-get update + replace blocked s0 action

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -135,13 +135,17 @@ jobs:
           cd ..
           # make -f pracs/Makefile clean
           make -f lectures/Makefile clean
-      - name: Deploy
-        uses: s0/git-publish-subdir-action@develop
+      - name: Deploy to gh-spe-material branch
         env:
-          REPO: self
-          BRANCH: gh-spe-material
-          FOLDER: deploy
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd deploy
+          git init -q -b gh-spe-material
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "Deploy ${GITHUB_SHA::7} from ${GITHUB_REF_NAME}"
+          git push -q --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-spe-material
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The third-party action s0/git-publish-subdir-action@develop is being blocked by GitHub (Repository access blocked) and is pinned to a branch (not a tag), which is a supply-chain risk in itself. Replace with a few git commands that achieve the same: init a fresh repo in deploy/, commit, and force-push to gh-spe-material.