### PR TITLE
Install libnode-dev so V8 R package can load at runtime

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install other needed libs
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev
+          sudo apt-get install -y libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev libnode-dev
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install TinyTeX


### PR DESCRIPTION
The V8 R package (transitively required by dagitty for the causal inference practicals) loads libnode.so at startup. On Ubuntu 24.04 that shared library is provided by libnode109, pulled in by the libnode-dev meta-package. Without it the V8.so library file is built but fails to dlopen, aborting the bookdown render at the dagitty chunk.