### PR TITLE
Fix stuck checkout-and-deploy: ubuntu-latest + checkout@v4

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -14,7 +14,7 @@ jobs:
     name: Render-Book
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # More detail here, https://github.com/r-lib/actions
       # It's possible to define R and pandoc version if desired
       - name: Install other needed libs
@@ -58,7 +58,7 @@ jobs:
           path: _book
 
   checkout-and-deploy:
-   runs-on: ubuntu-20.04
+   runs-on: ubuntu-latest
    needs: bookdown
    steps:
      - name: Checkout


### PR DESCRIPTION
The checkout-and-deploy job was pinned to runs-on: ubuntu-20.04, which GitHub retired in April 2025. Jobs targeting that label now sit in the queue indefinitely (Damien hit a 24h queue timeout). Switch both jobs to ubuntu-latest and bump the lingering actions/checkout@v2 in the bookdown job to @v4 to match the deploy job.

Closes Phase 1.1 and Phase 1.2 of the 2026 modernization plan.