### PR TITLE
Finish Phase 1: checkout@v4 in jekyll, pin r-lib to v2.12.0

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -21,15 +21,15 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev libnode-dev
-      - uses: r-lib/actions/setup-r@v2
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2.12.0
+      - uses: r-lib/actions/setup-pandoc@v2.12.0
       - name: Install TinyTeX
-        uses: r-lib/actions/setup-tinytex@v2
+        uses: r-lib/actions/setup-tinytex@v2.12.0
         env:
           # install full prebuilt version
           TINYTEX_INSTALLER: TinyTeX
       - name: Install R packages
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@v2.12.0
       - name: Install rmarkdown
         run: Rscript -e 'install.packages(c("rmarkdown","bookdown"))'
       - name: Render html Book

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # - name: Install curl and some other needed libs
       #   run: |
       #     sudo apt-get install -y libcurl4-openssl-dev
@@ -82,9 +82,9 @@ jobs:
       - name: Setup cmake
         run: sudo apt-get install -y cmake
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v2.12.0
       - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@v2.12.0
       - name: Install R packages
         run: Rscript -e 'install.packages(c("rmarkdown", "bookdown", "renv", "knitr", "stringr"))' 
       # - name: Setup tmate session


### PR DESCRIPTION
…12.0

Two trailing hygiene cleanups now that both workflows are validated:

1. Bump actions/checkout@v3 to @v4 in jekyll-gh-pages.yml. Matches the version already used in deploy_bookdown.yml; @v3 still works but the inconsistency is no longer worth keeping.

2. Pin all r-lib/actions/* (setup-r, setup-pandoc, setup-tinytex, setup-renv) from the floating @v2 tag to a specific release @v2.12.0 (latest as of 2026-04-30). Floating tags can silently change behavior on any future run; pinning gives us reproducible CI builds that we explicitly opt into upgrading.